### PR TITLE
button-group: only set `aria-pressed` when changed

### DIFF
--- a/button-group/button-group.js
+++ b/button-group/button-group.js
@@ -80,10 +80,10 @@ export default class ButtonGroup extends HTMLElement {
 				button.type = "button";
 			}
 
-			let pressed = getValue(button) === value;
+			let ariaPressed = (getValue(button) === value).toString();
 
-			if (pressed !== button.getAttribute("aria-pressed")) {
-				button.setAttribute("aria-pressed", pressed);
+			if (ariaPressed !== button.getAttribute("aria-pressed")) {
+				button.setAttribute("aria-pressed", ariaPressed);
 			}
 		}
 	}


### PR DESCRIPTION
Previously, the check for determining whether the value of `aria-pressed` had changed was done by
comparing the button's pressed state (a boolean) with the return value of
`getAttribute("aria-pressed")`, which always returns a string (or `null`). This resulted in
unnecessarily re-setting the `aria-pressed` attribute when the new state matched the previous one.

This change avoids this by converting the new pressed state to a string (i.e. `"true"/"false"`),
before comparing it with the return value of `getAttribute("aria-pressed")`.